### PR TITLE
스티디 신청

### DIFF
--- a/src/models/StudyMember.js
+++ b/src/models/StudyMember.js
@@ -1,0 +1,27 @@
+export default (sequelize, DataTypes) => {
+    return sequelize.define("StudyMember", {
+        isApprove: {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false,
+            comment: "신청 승인 여부"
+        },
+        isReject: {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false,
+            comment: "신청 거절 여부"
+        },
+        rejectReason: {
+            type: DataTypes.STRING,
+            comment: "거절 사유"
+        },
+        isBanish: {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false,
+            comment: "추방 여부"
+        },
+        banishReason: {
+            type: DataTypes.STRING,
+            comment: "추방 사유"
+        }
+    });
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -41,9 +41,11 @@ db.Sequelize = Sequelize;
 
 db.User.hasMany(db.Study);
 db.User.hasMany(db.StudyBoard);
+db.User.hasMany(db.StudyMember);
 
 db.Study.hasMany(db.StudyDay);
 db.Study.hasMany(db.StudyBoard);
+db.Study.hasMany(db.StudyMember);
 db.Study.belongsTo(db.User);
 db.Study.belongsTo(db.StudySubject);
 
@@ -53,5 +55,8 @@ db.StudySubject.hasMany(db.Study);
 
 db.StudyBoard.belongsTo(db.User);
 db.StudyBoard.belongsTo(db.Study);
+
+db.StudyMember.belongsTo(db.User);
+db.StudyMember.belongsTo(db.Study);
 
 export default db;

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,16 +1,23 @@
 import usersQuery from "./resolvers/query/users";
 import studyBoardQuery from "./resolvers/query/studyBoard";
+import studyMemberQuery from "./resolvers/query/studyMember";
 
 import usersMutation from "./resolvers/mutation/users";
 import studyMutations from "./resolvers/mutation/studies";
 import studyBoardMutations from "./resolvers/mutation/studyBoard";
+import studyMemberMutations from "./resolvers/mutation/studyMember";
 
 const resolvers = {
-  Query: { ...usersQuery, ...studyBoardQuery },
+  Query: {
+    ...usersQuery,
+    ...studyBoardQuery,
+    ...studyMemberQuery
+  },
   Mutation: {
     ...usersMutation,
     ...studyMutations,
-    ...studyBoardMutations
+    ...studyBoardMutations,
+    ...studyMemberMutations
   }
 };
 

--- a/src/resolvers/mutation/studyMember.js
+++ b/src/resolvers/mutation/studyMember.js
@@ -1,0 +1,55 @@
+import models from "../../models";
+import { authenticatedMiddleware } from "../../utils/middleware";
+
+const createMember = async (_, {studyId}, {user}) => {
+    const [member, created] = await models.StudyMember.findOrCreate({
+        where: { StudyId: studyId, UserId: user.id },
+        defaults: {
+            StudyId: studyId,
+            UserId: user.id
+        }
+    });
+
+    if (!created) throw new Error('이미 신청하신 스터디입니다.');
+
+    return member;
+};
+
+const updateMember = async (_, {params, studyId}, {user}) => {
+    const isStudyAdmin = await models.Study.findOne({
+        where: {
+            UserId: user.id,
+            id: studyId
+        }
+    });
+
+    if (!isStudyAdmin) throw new Error('스터디를 생성한 관리자만 수정가능합니다.');
+
+    const members = await Promise.all(params.map(async param => {
+        const member = await models.StudyMember.findByPk(param.id);
+        return member.update(param)
+    }));
+
+    return members;
+};
+
+const deleteMember = async (_, {studyId}, {user}) => {
+    const member = await models.StudyMember.findOne({
+        where: {
+            UserId: user.id,
+            StudyId: studyId
+        }
+    });
+
+    if (!member) throw new Error('일치하는 스터디 회원이 존재하지 않습니다.');
+    await member.destroy();
+    return {isSuccess: true}
+};
+
+const studyMemberMutations = {
+    createMember: authenticatedMiddleware(createMember),
+    updateMember: authenticatedMiddleware(updateMember),
+    deleteMember: authenticatedMiddleware(deleteMember)
+};
+
+export default studyMemberMutations;

--- a/src/resolvers/mutation/studyMember.js
+++ b/src/resolvers/mutation/studyMember.js
@@ -1,5 +1,5 @@
 import models from "../../models";
-import { authenticatedMiddleware } from "../../utils/middleware";
+import {authenticatedMiddleware, authenticatedStudyAdminMiddleware} from "../../utils/middleware";
 
 const createMember = async (_, {studyId}, {user}) => {
     const [member, created] = await models.StudyMember.findOrCreate({
@@ -15,16 +15,7 @@ const createMember = async (_, {studyId}, {user}) => {
     return member;
 };
 
-const updateMember = async (_, {params, studyId}, {user}) => {
-    const isStudyAdmin = await models.Study.findOne({
-        where: {
-            UserId: user.id,
-            id: studyId
-        }
-    });
-
-    if (!isStudyAdmin) throw new Error('스터디를 생성한 관리자만 수정가능합니다.');
-
+const updateMember = async (_, {params}) => {
     const members = await Promise.all(params.map(async param => {
         const member = await models.StudyMember.findByPk(param.id);
         return member.update(param)
@@ -48,7 +39,7 @@ const deleteMember = async (_, {studyId}, {user}) => {
 
 const studyMemberMutations = {
     createMember: authenticatedMiddleware(createMember),
-    updateMember: authenticatedMiddleware(updateMember),
+    updateMember: authenticatedStudyAdminMiddleware(updateMember),
     deleteMember: authenticatedMiddleware(deleteMember)
 };
 

--- a/src/resolvers/query/studyMember.js
+++ b/src/resolvers/query/studyMember.js
@@ -1,0 +1,41 @@
+import models from "../../models";
+import {authenticatedStudyMemberMiddleware} from "../../utils/middleware";
+import calculatePagination from "../../utils/calculatePagination";
+
+const getStudyMembers = async (_, {paginationParams, params, studyId}) => {
+    const {
+        isApprove,
+        isReject,
+        isBanish,
+        orderBy = 'createdAt',
+        orderDirection = 'DESC'
+    } = params;
+    const where = {
+        StudyId: studyId
+    };
+    const order = [[orderBy, orderDirection]];
+
+    if (typeof isApprove === 'boolean') where.isApprove = isApprove;
+    if (typeof isReject === 'boolean') where.isReject = isReject;
+    if (typeof isBanish === 'boolean') where.isBanish = isBanish;
+
+    const members = await models.StudyMember.findAndCountAll({
+        where,
+        order,
+        ...calculatePagination({...paginationParams}),
+        include: [{
+            model: models.User,
+            attributes: {
+                exclude: ['password']
+            }
+        }]
+    });
+
+    return members;
+};
+
+const studyMemberQuery = {
+    getStudyMembers: authenticatedStudyMemberMiddleware(getStudyMembers)
+};
+
+export default studyMemberQuery;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -5,6 +5,7 @@
 # import * from "./schema/studies.graphql"
 # import * from "./schema/common.graphql"
 # import * from "./schema/studyBoard.graphql"
+# import * from "./schema/studyMember.graphql"
 
 type Query {
   getUsers: GetUsers
@@ -12,6 +13,7 @@ type Query {
   getStudyBoards: GetStudyBoards
   getStudyBoardById(id: Int!): StudyBoard
   getStudyBoardsByCategory(category: StudyBoardCategory): GetStudyBoards
+  getStudyMembers(paginationParams: PaginationInput, params: GetStudyMemberInput, studyId: Int!): GetStudyMember
 }
 
 type Mutation {
@@ -26,4 +28,7 @@ type Mutation {
   createStudyBoard(params: StudyBoardInput): StudyBoard
   deleteStudyBoard(id: Int!): Success
   updateStudyBoard(params: StudyBoardInput): StudyBoard
+  createMember(studyId: Int!): StudyMember
+  updateMember(params: [StudyMemberInput], studyId: Int!): [StudyMember]
+  deleteMember(studyId: Int!): Success
 }

--- a/src/schema/inputs/common.graphql
+++ b/src/schema/inputs/common.graphql
@@ -1,0 +1,4 @@
+input PaginationInput {
+    page: Int
+    pageSize: Int
+}

--- a/src/schema/inputs/index.graphql
+++ b/src/schema/inputs/index.graphql
@@ -1,3 +1,5 @@
+# import * from "./common.graphql"
 # import * from "./users.graphql"
 # import * from "./studies.graphql"
 # import * from "./studyBoard.graphql"
+# import * from "./studyMember.graphql"

--- a/src/schema/inputs/studyMember.graphql
+++ b/src/schema/inputs/studyMember.graphql
@@ -1,0 +1,16 @@
+input StudyMemberInput {
+    id: ID!
+    isApprove: Boolean
+    isReject: Boolean
+    rejectReason: String
+    isBanish: Boolean
+    banishReason: String
+}
+
+input GetStudyMemberInput {
+    isApprove: Boolean
+    isReject: Boolean
+    isBanish: Boolean
+    orderBy: String
+    orderDirection: String
+}

--- a/src/schema/interfaces/index.graphql
+++ b/src/schema/interfaces/index.graphql
@@ -2,3 +2,4 @@
 # import * from "./users.graphql"
 # import * from "./studies.graphql"
 # import * from "./studyBoard.graphql"
+# import * from "./studyMember.graphql"

--- a/src/schema/interfaces/studyMember.graphql
+++ b/src/schema/interfaces/studyMember.graphql
@@ -1,0 +1,10 @@
+interface IStudyMember {
+    id: ID
+    isApprove: Boolean
+    isReject: Boolean
+    rejectReason: String
+    isBanish: Boolean
+    banishReason: String
+    UserId: Int
+    StudyId: Int
+}

--- a/src/schema/studyMember.graphql
+++ b/src/schema/studyMember.graphql
@@ -1,0 +1,18 @@
+type StudyMember implements IStudyMember & IDate {
+    id: ID
+    isApprove: Boolean
+    isReject: Boolean
+    rejectReason: String
+    isBanish: Boolean
+    banishReason: String
+    UserId: Int
+    StudyId: Int
+    createdAt: String
+    updatedAt: String
+    User: User
+}
+
+type GetStudyMember implements IPagination {
+    count: Int!
+    rows: [StudyMember]
+}

--- a/src/utils/calculatePagination.js
+++ b/src/utils/calculatePagination.js
@@ -1,0 +1,7 @@
+const calculatePagination = ({page = 0, pageSize = 10}) => {
+    const limit = +pageSize;
+    const offset = +page > 1 ? (+page - 1) * limit : 0;
+    return { offset, limit }
+};
+
+export default calculatePagination;

--- a/src/utils/middleware.js
+++ b/src/utils/middleware.js
@@ -36,6 +36,23 @@ export const authenticatedStudyMemberMiddleware = next => async (root, args, con
     return next(root, args, context, info);
 };
 
+export const authenticatedStudyAdminMiddleware = next => async (root, args, context, info) => {
+    if (!context.user) {
+        throw new Error("잘못된 접근입니다.");
+    }
+
+    const isStudyAdmin = await models.Study.findOne({
+        where: {
+            UserId: context.user.id,
+            id: args.studyId
+        }
+    });
+
+    if (!isStudyAdmin) throw new Error('스터디를 생성한 관리자만 수정가능합니다.');
+
+    return next(root, args, context, info);
+};
+
 export const authenticatedAdminMiddleware = next => (root, args, context, info) => {
     if (!context.user) {
         throw new Error("잘못된 접근입니다.");

--- a/src/utils/middleware.js
+++ b/src/utils/middleware.js
@@ -1,6 +1,36 @@
+import models from '../models'
+
 export const authenticatedMiddleware = next => (root, args, context, info) => {
     if (!context.user) {
         throw new Error("잘못된 접근입니다.");
+    }
+
+    return next(root, args, context, info);
+};
+
+export const authenticatedStudyMemberMiddleware = next => async (root, args, context, info) => {
+    if (!context.user) {
+        throw new Error("잘못된 접근입니다.");
+    }
+
+    const isStudyAdmin = await models.Study.findOne({
+        where: {
+            UserId: context.user.id,
+            id: args.studyId
+        }
+    });
+
+    if (!isStudyAdmin) {
+        const member = await models.StudyMember.findOne({
+            where: {
+                UserId: context.user.id,
+                StudyId: args.studyId
+            }
+        });
+
+        if (!member) throw new Error('일치하는 스터디 회원이 존재하지 않습니다.');
+        if (member.isBanish) throw new Error('스터디장으로 부터 추방 당하셨습니다ㅠㅠ');
+        if (member.isReject) throw new Error('스터디 신청이 거절되었습니다ㅠㅠ');
     }
 
     return next(root, args, context, info);


### PR DESCRIPTION
## 스티디 신청
### Query
- 스터디원 검색
### Mutation
- 스터디 신청
- 신청 승인
- 신청 거절
- 스터디원 추방
### DB Table
- StudyMember 추가
- User (1:N) , Study(1:N) 관계 생성

### Query
- getStudyMembers
조건 검색 가능하도록 params로 받아서 where 절 생성
정렬 기능 추가

### Mutation
- createMember : findOrCreate로 중복 신청 불가능 하도록 구현
- updateMember: params를 배열로 넘겨받아 한번에 다중 사용자 수정이 가능하도록 구현
- deleteMember

### Input
- PaginationInput 추가 (공통 사용)
- StudyMember 관련 input 추가

### Interface
- StudyMember 관련 interface 추가

### util
- calculatePagination : pagination 사용시 offset과 limit을 계산해주는 함수 (default: page 1 / pageSize 10 )
- authenticatedStudyMemberMiddleware: 스터디 멤버의 계정 유효성 체크
접근 불가 케이스
1. 신청 거절 당한 경우
2. 스터디 추방 당한 경우
- authenticatedStudyAdminMiddleware : 스터디장 계정 유효성 체크
