### PR TITLE
스터디 게시판 수정사항 반영

### DIFF
--- a/src/resolvers/mutation/studyBoard.js
+++ b/src/resolvers/mutation/studyBoard.js
@@ -1,5 +1,5 @@
 import models from "../../models";
-import { authenticatedMiddleware } from "../../utils/middleware";
+import { authenticatedMiddleware, authenticatedStudyMemberMiddleware } from "../../utils/middleware";
 
 // 게시판 글 생성
 const createStudyBoard = async (_, { params }, context) => {
@@ -10,15 +10,8 @@ const createStudyBoard = async (_, { params }, context) => {
 };
 
 // 게시판 글 삭제
-const deleteStudyBoard = async (_, { id, studyId }, context) => {
+const deleteStudyBoard = async (_, { id }, context) => {
   const user = context.user;
-  const isStudyAdmin = await models.Study.findOne({
-    where: {
-      UserId: user.id,
-      id: studyId
-    }
-  });
-
   const promises = [];
 
   const studyBoardComments = await models.StudyBoardComment.findAll({
@@ -34,7 +27,7 @@ const deleteStudyBoard = async (_, { id, studyId }, context) => {
   const studyBoard = await models.StudyBoard.findOne({
     where: { id, UserId: user.id }
   });
-  if (!isStudyAdmin || !studyBoard)
+  if (!studyBoard)
     throw new Error("본인의 게시물만 삭제할 수 있습니다.");
 
   await Promise.all([...promises, studyBoard.destroy()]);
@@ -57,8 +50,8 @@ const updateStudyBoard = async (_, { params }, context) => {
 
 const studyBoardMutations = {
   createStudyBoard: authenticatedMiddleware(createStudyBoard),
-  deleteStudyBoard: authenticatedMiddleware(deleteStudyBoard),
-  updateStudyBoard: authenticatedMiddleware(updateStudyBoard)
+  deleteStudyBoard: authenticatedStudyMemberMiddleware(deleteStudyBoard),
+  updateStudyBoard: authenticatedStudyMemberMiddleware(updateStudyBoard)
 };
 
 export default studyBoardMutations;

--- a/src/resolvers/mutation/studyBoard.js
+++ b/src/resolvers/mutation/studyBoard.js
@@ -10,10 +10,19 @@ const createStudyBoard = async (_, { params }, context) => {
 };
 
 // 게시판 글 삭제
-const deleteStudyBoard = async (_, { id }, context) => {
+const deleteStudyBoard = async (_, { id, studyId }, context) => {
   const user = context.user;
-  const studyBoard = await models.StudyBoard.findByPk(id);
-  if (!user.isAdmin && studyBoard.UserId !== user.id)
+  const isStudyAdmin = await models.Study.findOne({
+    where: {
+      UserId: user.id,
+      id: studyId
+    }
+  });
+
+  const studyBoard = await models.StudyBoard.findOne({
+    where: { id, UserId: user.id }
+  });
+  if (!isStudyAdmin || !studyBoard)
     throw new Error("본인의 게시물만 삭제할 수 있습니다.");
 
   await studyBoard.destroy();

--- a/src/resolvers/mutation/studyBoard.js
+++ b/src/resolvers/mutation/studyBoard.js
@@ -19,13 +19,25 @@ const deleteStudyBoard = async (_, { id, studyId }, context) => {
     }
   });
 
+  const promises = [];
+
+  const studyBoardComments = await models.StudyBoardComment.findAll({
+    where: {
+      StudyBoardId: id
+    }
+  });
+
+  studyBoardComments.forEach(studyBoardComment => {
+    promises.push(studyBoardComment.destroy());
+  });
+
   const studyBoard = await models.StudyBoard.findOne({
     where: { id, UserId: user.id }
   });
   if (!isStudyAdmin || !studyBoard)
     throw new Error("본인의 게시물만 삭제할 수 있습니다.");
 
-  await studyBoard.destroy();
+  await Promise.all([...promises, studyBoard.destroy()]);
 
   return { isSuccess: true };
 };

--- a/src/resolvers/query/studyBoard.js
+++ b/src/resolvers/query/studyBoard.js
@@ -7,7 +7,9 @@ const getStudyBoards = async (
   _,
   { paginationParams, studyId: StudyId, category }
 ) => {
-  const where = {};
+  const where = {
+    StudyId
+  };
 
   if (category) {
     where.category = category;
@@ -15,7 +17,6 @@ const getStudyBoards = async (
 
   const studyBoards = await models.StudyBoard.findAndCountAll({
     where,
-    StudyId,
     ...calculatePagination({ ...paginationParams })
   });
 

--- a/src/resolvers/query/studyBoard.js
+++ b/src/resolvers/query/studyBoard.js
@@ -1,8 +1,23 @@
 import models from "../../models";
+import calculatePagination from "../../utils/calculatePagination";
+import { authenticatedStudyMemberMiddleware } from "../../utils/middleware";
 
 // 스터디 게시판 목록 가져오기
-const getStudyBoards = async () => {
-  const studyBoards = await models.StudyBoard.findAndCountAll();
+const getStudyBoards = async (
+  _,
+  { paginationParams, studyId: StudyId, category }
+) => {
+  const where = {};
+
+  if (category) {
+    where.category = category;
+  }
+
+  const studyBoards = await models.StudyBoard.findAndCountAll({
+    where,
+    StudyId,
+    ...calculatePagination({ ...paginationParams })
+  });
 
   return studyBoards;
 };
@@ -14,19 +29,9 @@ const getStudyBoardById = async (_, { id }) => {
   return studyBoard;
 };
 
-// 카테고리 별 스터디 게시판 목록 가져오기
-const getStudyBoardsByCategory = async (_, { category }) => {
-  const studyBoards = await models.StudyBoard.findAndCountAll({
-    where: { category }
-  });
-
-  return studyBoards;
-};
-
 const studyBoardQuery = {
-  getStudyBoards,
-  getStudyBoardById,
-  getStudyBoardsByCategory
+  getStudyBoards: authenticatedStudyMemberMiddleware(getStudyBoards),
+  getStudyBoardById: authenticatedStudyMemberMiddleware(getStudyBoardById)
 };
 
 export default studyBoardQuery;

--- a/src/resolvers/query/studyBoardComment.js
+++ b/src/resolvers/query/studyBoardComment.js
@@ -1,9 +1,14 @@
 import models from "../../models";
+import calculatePagination from "../../utils/calculatePagination";
 
 // 게시판 댓글 가져오기
-const getStudyBoardComments = async (_, { studyBoardId }) => {
-  const studyBoardComments = await models.StudyBoardComment.findAll({
-    where: { StudyBoardId: studyBoardId }
+const getStudyBoardComments = async (
+  _,
+  { paginationParams, studyBoardId: StudyBoardId }
+) => {
+  const studyBoardComments = await models.StudyBoardComment.findAndCountAll({
+    where: { StudyBoardId },
+    ...calculatePagination({ ...paginationParams })
   });
 
   return studyBoardComments;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -44,7 +44,7 @@ type Mutation {
   deleteUser: Success
   createStudyBoard(params: StudyBoardInput): StudyBoard
   deleteStudyBoard(id: Int!, studyId: Int!): Success
-  updateStudyBoard(params: StudyBoardInput): StudyBoard
+  updateStudyBoard(params: StudyBoardInput, studyId: Int!): StudyBoard
   createStudyBoardComment(
     comment: String!
     studyBoardId: Int!

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -37,7 +37,7 @@ type Mutation {
   resetPassword(email: String!): Success
   deleteUser: Success
   createStudyBoard(params: StudyBoardInput): StudyBoard
-  deleteStudyBoard(id: Int!): Success
+  deleteStudyBoard(id: Int!, studyId: Int!): Success
   updateStudyBoard(params: StudyBoardInput): StudyBoard
   createStudyBoardComment(
     comment: String!

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -18,7 +18,10 @@ type Query {
     category: StudyBoardCategory
   ): GetStudyBoards
   getStudyBoardById(id: Int!): StudyBoard
-  getStudyBoardComments(studyBoardId: Int!): [StudyBoardComment]
+  getStudyBoardComments(
+    paginationParams: PaginationInput
+    studyBoardId: Int!
+  ): GetStudyBoardComments
   getStudyMembers(
     paginationParams: PaginationInput
     params: GetStudyMemberInput

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -12,9 +12,12 @@
 type Query {
   getUsers: GetUsers
   getUserById(id: Int!): User
-  getStudyBoards: GetStudyBoards
+  getStudyBoards(
+    paginationParams: PaginationInput
+    studyId: Int!
+    category: StudyBoardCategory
+  ): GetStudyBoards
   getStudyBoardById(id: Int!): StudyBoard
-  getStudyBoardsByCategory(category: StudyBoardCategory): GetStudyBoards
   getStudyBoardComments(studyBoardId: Int!): [StudyBoardComment]
   getStudyMembers(
     paginationParams: PaginationInput

--- a/src/schema/studyBoardComment.graphql
+++ b/src/schema/studyBoardComment.graphql
@@ -6,3 +6,8 @@ type StudyBoardComment implements IStudyBoardComment & IDate {
   createdAt: String
   updatedAt: String
 }
+
+type GetStudyBoardComments implements IPagination {
+  count: Int!
+  rows: [StudyBoardComment]
+}

--- a/src/utils/middleware.js
+++ b/src/utils/middleware.js
@@ -1,66 +1,83 @@
-import models from '../models'
+import models from "../models";
 
 export const authenticatedMiddleware = next => (root, args, context, info) => {
-    if (!context.user) {
-        throw new Error("잘못된 접근입니다.");
-    }
+  if (!context.user) {
+    throw new Error("잘못된 접근입니다.");
+  }
 
-    return next(root, args, context, info);
+  return next(root, args, context, info);
 };
 
-export const authenticatedStudyMemberMiddleware = next => async (root, args, context, info) => {
-    if (!context.user) {
-        throw new Error("잘못된 접근입니다.");
-    }
+export const authenticatedStudyMemberMiddleware = next => async (
+  root,
+  args,
+  context,
+  info
+) => {
+  if (!context.user) {
+    throw new Error("잘못된 접근입니다.");
+  }
 
-    const isStudyAdmin = await models.Study.findOne({
-        where: {
-            UserId: context.user.id,
-            id: args.studyId
-        }
+  const isStudyAdmin = await models.Study.findOne({
+    where: {
+      UserId: context.user.id,
+      id: args.studyId
+    }
+  });
+
+  if (!isStudyAdmin) {
+    const member = await models.StudyMember.findOne({
+      where: {
+        UserId: context.user.id,
+        StudyId: args.studyId
+      }
     });
 
-    if (!isStudyAdmin) {
-        const member = await models.StudyMember.findOne({
-            where: {
-                UserId: context.user.id,
-                StudyId: args.studyId
-            }
-        });
+    if (!member) throw new Error("일치하는 스터디 회원이 존재하지 않습니다.");
+    if (member.isBanish)
+      throw new Error("스터디장으로 부터 추방 당하셨습니다ㅠㅠ");
+    if (member.isReject) throw new Error("스터디 신청이 거절되었습니다ㅠㅠ");
+  }
 
-        if (!member) throw new Error('일치하는 스터디 회원이 존재하지 않습니다.');
-        if (member.isBanish) throw new Error('스터디장으로 부터 추방 당하셨습니다ㅠㅠ');
-        if (member.isReject) throw new Error('스터디 신청이 거절되었습니다ㅠㅠ');
-    }
-
-    return next(root, args, context, info);
+  return next(root, args, context, info);
 };
 
-export const authenticatedStudyAdminMiddleware = next => async (root, args, context, info) => {
-    if (!context.user) {
-        throw new Error("잘못된 접근입니다.");
+export const authenticatedStudyAdminMiddleware = next => async (
+  root,
+  args,
+  context,
+  info
+) => {
+  if (!context.user) {
+    throw new Error("잘못된 접근입니다.");
+  }
+
+  const isStudyAdmin = await models.Study.findOne({
+    where: {
+      UserId: context.user.id,
+      id: args.studyId
     }
+  });
 
-    const isStudyAdmin = await models.Study.findOne({
-        where: {
-            UserId: context.user.id,
-            id: args.studyId
-        }
-    });
+  if (!isStudyAdmin)
+    throw new Error("스터디를 생성한 관리자만 수정가능합니다.");
 
-    if (!isStudyAdmin) throw new Error('스터디를 생성한 관리자만 수정가능합니다.');
-
-    return next(root, args, context, info);
+  return next(root, args, context, info);
 };
 
-export const authenticatedAdminMiddleware = next => (root, args, context, info) => {
-    if (!context.user) {
-        throw new Error("잘못된 접근입니다.");
-    }
+export const authenticatedAdminMiddleware = next => (
+  root,
+  args,
+  context,
+  info
+) => {
+  if (!context.user) {
+    throw new Error("잘못된 접근입니다.");
+  }
 
-    if (!context.user.isAdmin) {
-        throw new Error("관리자만 접근 가능합니다.")
-    }
+  if (!context.user.isAdmin) {
+    throw new Error("관리자만 접근 가능합니다.");
+  }
 
-    return next(root, args, context, info);
+  return next(root, args, context, info);
 };


### PR DESCRIPTION
### mutation/`deleteStudyBoard`
- 스터디장은 게시판 글을 삭제할 수 있도록 변경 (기존에 isAdmin으로 되어 있었음)
- 게시판 삭제 시 해당 게시판의 댓글들도 삭제되도록 수정

### query/`getStudyBoards`
- 페이지네이션 (paginationParams) 추가
- 기존 카테고리별 스터디 게시판 가져오기 API를 제거하고 getStudyBoards에 합침
- 스터디 멤버인지 확인하는 미들웨어 적용

### query/`getStudyBoardComments`
- 페이지네이션 (paginationParams) 추가