### PR TITLE
사용자 초대 API 추가

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const server = new ApolloServer({
       if (!user.id) throw new Error("잘못된 접근입니다.");
       const _user = await models.User.findByPk(user.id);
       if (!_user) throw new Error("존재하지 않는 회원입니다.");
-      return { user: _user, token };
+      return { user: _user, token, ...user };
     }
   }
 });

--- a/index.js
+++ b/index.js
@@ -26,11 +26,11 @@ const server = new ApolloServer({
   context: async ({ req }) => {
     const token = req.headers["sb-token"] || "";
     if (token) {
-      const user = await verifyToken(token);
-      if (!user.id) throw new Error("잘못된 접근입니다.");
-      const _user = await models.User.findByPk(user.id);
+      const verifiedToken = await verifyToken(token);
+      if (!verifiedToken.id) throw new Error("잘못된 접근입니다.");
+      const _user = await models.User.findByPk(verifiedToken.id);
       if (!_user) throw new Error("존재하지 않는 회원입니다.");
-      return { user: _user, token, ...user };
+      return { user: _user, token, ...verifiedToken };
     }
   }
 });

--- a/src/resolvers/mutation/studies.js
+++ b/src/resolvers/mutation/studies.js
@@ -7,6 +7,7 @@ const createStudy = async (_, {params}) => {
     return study;
 };
 
+
 const studyMutations = {
     createStudy
 };

--- a/src/resolvers/mutation/studyMember.js
+++ b/src/resolvers/mutation/studyMember.js
@@ -1,5 +1,9 @@
 import models from "../../models";
 import {authenticatedMiddleware, authenticatedStudyAdminMiddleware} from "../../utils/middleware";
+import {Op} from "sequelize";
+import {asyncForEach} from "../../utils/asyncForEach";
+import {createToken} from "../../utils/token";
+import {getMailInviteStudy, sendMail} from "../../utils/mailer";
 
 const createMember = async (_, {studyId}, {user}) => {
     const [member, created] = await models.StudyMember.findOrCreate({
@@ -13,6 +17,62 @@ const createMember = async (_, {studyId}, {user}) => {
     if (!created) throw new Error('이미 신청하신 스터디입니다.');
 
     return member;
+};
+
+const createMemberByInvite = async (_, args, {user, StudyId}) => {
+    const [member, created] = await models.StudyMember.findOrCreate({
+        where: { StudyId, UserId: user.id },
+        defaults: {
+            StudyId,
+            UserId: user.id,
+            isApprove: true
+        }
+    });
+
+    if (!created) throw new Error('이미 신청하신 스터디입니다.');
+
+    return member;
+};
+
+const sendMailToInvitedUsers = async (_, { userIds, studyId: StudyId}) => {
+    if (!userIds.length) throw new UserInputError('초대할 사용자를 선택해주세요.');
+    const alreadyMembers = await models.StudyMember.findAll({
+        where: {
+            StudyId,
+            UserId: {
+                [Op.or]: userIds
+            }
+        }
+    });
+
+    if (alreadyMembers.length) throw new UserInputError('이미 신청한 사용자가 존재합니다.');
+
+    const users = await models.User.findAll({
+        where: {
+            id: {
+                [Op.or]: userIds
+            }
+        }
+    });
+
+    const study = await models.Study.findByPk(StudyId);
+
+    const sendMailPromises = [];
+    await asyncForEach(users, async user => {
+        const token = await createToken({ id: user.id, StudyId});
+        sendMailPromises.push(
+            sendMail(
+                getMailInviteStudy({
+                    email: user.email,
+                    studyTitle: study.name,
+                    token
+                })
+            )
+        )
+    });
+
+    await Promise.all(sendMailPromises);
+    return { isSuccess: true }
 };
 
 const updateMember = async (_, {params}) => {
@@ -39,6 +99,8 @@ const deleteMember = async (_, {studyId}, {user}) => {
 
 const studyMemberMutations = {
     createMember: authenticatedMiddleware(createMember),
+    createMemberByInvite: authenticatedMiddleware(createMemberByInvite),
+    sendMailToInvitedUsers: authenticatedStudyAdminMiddleware(sendMailToInvitedUsers, '스터디를 생성한 관리자만 초대 가능합니다.'),
     updateMember: authenticatedStudyAdminMiddleware(updateMember),
     deleteMember: authenticatedMiddleware(deleteMember)
 };

--- a/src/resolvers/query/users.js
+++ b/src/resolvers/query/users.js
@@ -1,13 +1,23 @@
+import {Op} from 'sequelize';
 import models from "../../models";
+import calculatePagination from "../../utils/calculatePagination";
 
-const getUsers = async () => {
-  const users = await models.User.findAndCountAll({
-    where: {
-      deleted: false
-    }
+const getUsers = async (_, {paginationParams, searchingText = ''}) => {
+  const where = {};
+
+  if (searchingText) {
+    where[Op.or] = {
+        email: { [Op.like]: `%${searchingText}%` },
+        nickname: { [Op.like]: `%${searchingText}%` }
+    };
+  }
+
+  return await models.User.findAndCountAll({
+    where,
+    ...calculatePagination({...paginationParams})
   });
-  return users;
 };
+
 const getUserById = async (_, { id }) => {
   const user = await models.User.findByPk(id);
   return user;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -11,7 +11,7 @@
 # import * from "./schema/studyBookmark.graphql"
 
 type Query {
-  getUsers: GetUsers
+  getUsers(paginationParams: PaginationInput, searchingText: String): GetUsers
   getUserById(id: Int!): User
   getStudyBoards: GetStudyBoards
   getStudyBoardById(id: Int!): StudyBoard
@@ -46,8 +46,10 @@ type Mutation {
   deleteStudyBoardComment(id: Int!): Success
   updateStudyBoardComment(id: Int!, comment: String!): StudyBoardComment
   createMember(studyId: Int!): StudyMember
+  createMemberByInvite: StudyMember
   updateMember(params: [StudyMemberInput], studyId: Int!): [StudyMember]
   deleteMember(studyId: Int!): Success
   createStudyActionLog(status: StudyActionLogEnum!, studyId: Int!): Success
   toggleStudyBookmark(studyId: Int!): StudyBookmark
+  sendMailToInvitedUsers(userIds: [ID]!, studyId: Int!): Success
 }

--- a/src/utils/asyncForEach.js
+++ b/src/utils/asyncForEach.js
@@ -1,0 +1,5 @@
+export const asyncForEach = async function (array, callback) {
+    for (let index = 0; index < array.length; index++) {
+        await callback(array[index], index, array)
+    }
+}

--- a/src/utils/mailer.js
+++ b/src/utils/mailer.js
@@ -43,3 +43,11 @@ export const getMailResetPassword = ({email, newPassword}) => {
         content: `<div>비밀번호가 재발급 되었습니다. 보안을 위해 비밀번호를 변경해주세요!</div><div>변경된 비밀번호: ${newPassword}</div>`
     };
 };
+
+export const getMailInviteStudy = ({email, studyTitle, token}) => {
+    return {
+        to: email,
+        subject: '스터디부스터 초대 메일',
+        content: `<div><b>${studyTitle}</b>에 당신을 초대합니다. 아래 링크로 접속하면 자동으로 신청 완료됩니다.</div><div>초대 응답하기: ${process.env.HOST_NAME}/invited/${token}</div>`
+    };
+};

--- a/src/utils/middleware.js
+++ b/src/utils/middleware.js
@@ -36,7 +36,7 @@ export const authenticatedStudyMemberMiddleware = next => async (root, args, con
     return next(root, args, context, info);
 };
 
-export const authenticatedStudyAdminMiddleware = next => async (root, args, context, info) => {
+export const authenticatedStudyAdminMiddleware = (next, errorMessage) => async (root, args, context, info) => {
     if (!context.user) {
         throw new Error("잘못된 접근입니다.");
     }
@@ -48,7 +48,7 @@ export const authenticatedStudyAdminMiddleware = next => async (root, args, cont
         }
     });
 
-    if (!isStudyAdmin) throw new Error('스터디를 생성한 관리자만 수정가능합니다.');
+    if (!isStudyAdmin) throw new Error(errorMessage || '스터디를 생성한 관리자만 수정가능합니다.');
 
     return next(root, args, context, info);
 };


### PR DESCRIPTION
사용자 검색 후 다중선택으로 스터디 초대 메일 발송 후 토큰을 사용하여 스터디 멤버로 추가

## index.js(Node server)
- token으로 StudyId 를 담아서 보내주므로 validToken 된 데이터들을 전부 context에 담아줄 필요가 있음.

## createMemberByInvite
- token 에 담겨있는 StudyId와 UserId를 사용하여 스터디 멤버로 추가 (초대 된 멤버는 바로 승인완료)

## sendMailToInvitedUsers
- userIds (Array) 와 studyId를 params로 받음. (스터디 그룹장만 초대가능)
- userIds의 id 중 이미 신청을 한 사용자가 있다면 에러 발생
- 반복문에서 비동기로 토큰을 생성하고 비동기 메일 발송을 위한 `asyncForEach` 함수 추가

## getUsers
- pagination 정보 params와 text 검색(email, nickname) 추가

## authenticatedStudyAdminMiddleware
- 에러 메시지를 parameter에서 받아와서 사용할 수도 있도록 변경.
- 다른 middleware도 필요에 따라 추가 해 주는것이 좋을 것 같다.